### PR TITLE
Rename NFCMessage.data to NFCMessage.records

### DIFF
--- a/app/elements/weneed-nfc/weneed-nfc.html
+++ b/app/elements/weneed-nfc/weneed-nfc.html
@@ -35,7 +35,7 @@ Copyright (c) 2015, 2016 Intel Corporation. All rights reserved.
           }
 
           navigator.nfc.watch(message => {
-            for (let record of message.data) {
+            for (let record of message.records) {
               console.log(record.data);
               let name = record.data.name;
               this.onItemReceived(name);

--- a/app/elements/write-dialog/write-dialog.html
+++ b/app/elements/write-dialog/write-dialog.html
@@ -386,7 +386,7 @@ Copyright (c) 2015, 2016 Intel Corporation. All rights reserved.
           }
 
           navigator.nfc.push({
-            data: [
+            records: [
               {
                 recordType: "json",
                 mediaType: "application/json",


### PR DESCRIPTION
Implementation changed at https://chromium-review.googlesource.com/c/539599/
(Merged as https://chromium.googlesource.com/chromium/src/+/b1efd1e7b6d9eb46c2a367a84f8350623093ec14): [webnfc] Rename NFCMessage.data to NFCMessage.records.

Please help to update https://webnfc-shoppingcart.appspot.com/#!/home when the PR is merged.
